### PR TITLE
This fixes the role so that the service is enabled on debian jessie/8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
   - distro: ubuntu1204
     init: /sbin/init
     run_opts: ""
+  - distro: debian8
+    init: /lib/systemd/systemd
+    run_opts: ""
 
 before_install:
   # Pull container.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     run_opts: ""
   - distro: debian8
     init: /lib/systemd/systemd
-    run_opts: ""
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 before_install:
   # Pull container.

--- a/tasks/init-setup.yml
+++ b/tasks/init-setup.yml
@@ -14,8 +14,7 @@
     - { src: "{{ gogs_user_home }}/{{ gogs_init_script_path }}" , dest: "/etc/init.d/gogs" }
   notify: restart gogs
 
-
-- name: Enable Gogs service
-  command: systemctl enable gogs
-  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == "8"
-
+- name: Enable gogs service
+  service:
+    name: gogs
+    enabled: yes

--- a/tasks/init-setup.yml
+++ b/tasks/init-setup.yml
@@ -13,3 +13,9 @@
     - { src: "{{ gogs_user_home }}/gogs/gogs", dest: "/usr/local/bin/gogs" }
     - { src: "{{ gogs_user_home }}/{{ gogs_init_script_path }}" , dest: "/etc/init.d/gogs" }
   notify: restart gogs
+
+
+- name: Enable Gogs service
+  command: systemctl enable gogs
+  when: ansible_os_family == 'Debian' and ansible_distribution_major_version == "8"
+


### PR DESCRIPTION
The role previously did not enable the service correctly. (service "gogs" not found)

I also tested this with `service: name=gogs enabled=yes` but that did not work. (same error)

I therefore used the command module and added an OS filter.

I only tested this with debian jessie (since that's what I use)
